### PR TITLE
Update sources for working with newer swift(s)

### DIFF
--- a/Sources/ObservableSet.swift
+++ b/Sources/ObservableSet.swift
@@ -10,7 +10,7 @@ public typealias SetUpdate<Element: Hashable> = Update<SetChange<Element>>
 public typealias SetUpdateSource<Element: Hashable> = AnySource<Update<SetChange<Element>>>
 
 public protocol ObservableSetType: ObservableType where Change == SetChange<Element> {
-    associatedtype Element
+    associatedtype Element: Hashable
 
     typealias Base = Set<Element>
 

--- a/Sources/ObservableType.swift
+++ b/Sources/ObservableType.swift
@@ -56,7 +56,9 @@ public protocol UpdatableType: ObservableType {
     /// The current value of this observable.
     ///
     /// The setter is nonmutating because the value ultimately needs to be stored in a reference type anyway.
-    var value: Value { get nonmutating set }
+    /// for some reason new Swift version deosnt' want this property to be overloaded by other protocols
+    /// Tho the part below moved to  `UpdatableValueType`
+    //    var value: Value { get nonmutating set }
 
     func apply(_ update: Update<Change>)
 }

--- a/Sources/UpdatableValue.swift
+++ b/Sources/UpdatableValue.swift
@@ -10,6 +10,9 @@
 public protocol UpdatableValueType: ObservableValueType, UpdatableType {
     /// Returns the type-erased version of this UpdatableValueType.
     var anyUpdatableValue: AnyUpdatableValue<Value> { get }
+    
+    var value: Value { get nonmutating set }
+
 }
 
 extension UpdatableValueType {


### PR DESCRIPTION
`nonmutating` requirement cannot be used in the protocols without the known value
🤷‍♂️ 

This PR fixes this behaviour for the latest swift 4